### PR TITLE
feat: make `@parcel/fs-search` work

### DIFF
--- a/test/parcel_fs_search.js
+++ b/test/parcel_fs_search.js
@@ -1,0 +1,13 @@
+const lib = dlopen(
+  "./testdata/node_modules/@parcel/fs-search/fs-search.darwin-arm64.node",
+);
+
+const file = lib.findFirstFile(
+  [
+    "./test/example_non_existent.js",
+    "./test/example.js",
+    "./test/example_non_existent2.js",
+  ],
+);
+
+print(file); // ./test/example.js

--- a/testdata/package.json
+++ b/testdata/package.json
@@ -4,6 +4,7 @@
   "main": "index.js",
   "license": "MIT",
   "dependencies": {
+    "@parcel/fs-search": "^2.2.1",
     "@parcel/hash": "^2.2.1",
     "@parcel/optimizer-image": "^2.2.1",
     "@parcel/transformer-js": "^2.2.1",


### PR DESCRIPTION
Towards #12 

```javascript
const lib = dlopen(
  "./testdata/node_modules/@parcel/fs-search/fs-search.darwin-arm64.node",
);

const file = lib.findFirstFile(
  [
    "./test/example_non_existent.js",
    "./test/example.js",
    "./test/example_non_existent2.js",
  ],
);

print(file); // ./test/example.js
```