### PR TITLE
feat: make `@parcel/css` work

### DIFF
--- a/test/parcel_css.js
+++ b/test/parcel_css.js
@@ -1,0 +1,38 @@
+const lib = dlopen(
+  "./testdata/node_modules/@parcel/css-darwin-arm64/parcel-css.darwin-arm64.node",
+);
+
+// Test case from @parcel/css
+// https://github.com/parcel-bundler/parcel-css/blob/1e89b39cd922d2e577c8e39611f484a525fd8937/test.js
+const result = lib.transform({
+  filename: "test.css",
+  minify: false,
+  targets: {
+    safari: 4 << 16,
+    firefox: 3 << 16 | 5 << 8,
+    opera: 10 << 16 | 5 << 8,
+  },
+  code: Deno.core.encode(`
+  @import "foo.css";
+  @import "bar.css" print;
+  @import "baz.css" supports(display: grid);
+  .foo {
+      composes: bar;
+      composes: baz from "baz.css";
+      color: pink;
+  }
+  .bar {
+      color: red;
+      background: url(test.jpg);
+  }
+  `),
+  drafts: {
+    nesting: true,
+  },
+  cssModules: true,
+  analyzeDependencies: true,
+});
+
+print(Deno.core.decode(result.code));
+print(JSON.stringify(result.exports));
+print(JSON.stringify(result.dependencies));

--- a/testdata/package.json
+++ b/testdata/package.json
@@ -4,6 +4,7 @@
   "main": "index.js",
   "license": "MIT",
   "dependencies": {
+    "@parcel/css": "^1.2.0",
     "@parcel/fs-search": "^2.2.1",
     "@parcel/hash": "^2.2.1",
     "@parcel/optimizer-image": "^2.2.1",

--- a/testdata/yarn.lock
+++ b/testdata/yarn.lock
@@ -63,6 +63,62 @@
     slice-ansi "^4.0.0"
     string-width "^4.2.0"
 
+"@parcel/css-darwin-arm64@1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@parcel/css-darwin-arm64/-/css-darwin-arm64-1.2.0.tgz#c8e7665754da229e5be101611bd4b91c45316ab6"
+  integrity sha512-UzM9rv+ERUURVbQvNIN5SNBoU4ycJvLdqQbolDCmRvfBu6+tgM6n4W8nBp1cXpxh/iIsdHwDV2KPtK3XbKF1UQ==
+
+"@parcel/css-darwin-x64@1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@parcel/css-darwin-x64/-/css-darwin-x64-1.2.0.tgz#8e5317cf1b7cfdf45a57bebfca4bfd7919159097"
+  integrity sha512-M1yVWyTjXby6IzbSQlKpoyuAJIM1G7HVEI9ASYcmz0C3dsJqS8EW7IWjA/fJc/HevHoyGXIEYuIvrCc50bey0w==
+
+"@parcel/css-linux-arm-gnueabihf@1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@parcel/css-linux-arm-gnueabihf/-/css-linux-arm-gnueabihf-1.2.0.tgz#124ee1c8235842440cacc2d78b6153e7cc863993"
+  integrity sha512-kLf4OmglnCHOVFfrJLF1Uuxuo5ayCI5egAZRKhZSeZ9ua5KOioAPSwvieYZrI6esH0a/MUhfywn/7haKGfxwnA==
+
+"@parcel/css-linux-arm64-gnu@1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@parcel/css-linux-arm64-gnu/-/css-linux-arm64-gnu-1.2.0.tgz#f7581ba53587aa7bb5ad54e08849e8493f0460d9"
+  integrity sha512-dNnJLiAy2xXXDVVOeboDG2Rn6Ak9DsylRfKGdO2KvGj4MkwbV6fEBo4m9s73JKgsgtdGljWRcsTRPo23vaWBtw==
+
+"@parcel/css-linux-arm64-musl@1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@parcel/css-linux-arm64-musl/-/css-linux-arm64-musl-1.2.0.tgz#a498cdf7807a317950d358f25e6c3df6a0bc75f5"
+  integrity sha512-oOa55lM59KWDlD6SK2brLT+Oaj8rDQDVHkMUVipxh2vFEQMDeRm1k6seFN1EyMGwb67ixjaWbqDsVCwpSDAtag==
+
+"@parcel/css-linux-x64-gnu@1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@parcel/css-linux-x64-gnu/-/css-linux-x64-gnu-1.2.0.tgz#8cbf46109285d044b6aa05a68938d2edf698be0e"
+  integrity sha512-qyVozcROGm1oB2Sp4Qyzi4OLSAno31Q0/gofN5De2gycnqeG1k/dViIK37KMLjDQNVm2S2RfigLo79NbhNtOrw==
+
+"@parcel/css-linux-x64-musl@1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@parcel/css-linux-x64-musl/-/css-linux-x64-musl-1.2.0.tgz#05e69c799b33e7f6b833f5d0dec8747b79f3df2c"
+  integrity sha512-tBuaEcZ8kJECHxDv4goA2XXW/ZC9p0lmKf5HEEssF6coXlAXbcngF4V8E/NALuESLDIlhKbF+htbIS/GgpgvkQ==
+
+"@parcel/css-win32-x64-msvc@1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@parcel/css-win32-x64-msvc/-/css-win32-x64-msvc-1.2.0.tgz#f00a6f4f9b8ad089170eef4b9b03515bc3110933"
+  integrity sha512-r2nxgelC5T5+icP5+E/CTLpToRUbvtGVHZloinre3E3vJOAhe6uJJ5TCP8fr8H+KHjzHoQCy9H3VgFiQE8A3pg==
+
+"@parcel/css@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@parcel/css/-/css-1.2.0.tgz#481d1271e8c7c711dc6e4ad44428e5b617da4805"
+  integrity sha512-kFKigkVGgjE7wcs+BtQuk127C2/Tc42PGPS9qLePZWty7BL8ydBND+1Ef7dnx7qEqMU+6yKZBz97nG7LFJ27yA==
+  dependencies:
+    detect-libc "^1.0.3"
+  optionalDependencies:
+    "@parcel/css-darwin-arm64" "1.2.0"
+    "@parcel/css-darwin-x64" "1.2.0"
+    "@parcel/css-linux-arm-gnueabihf" "1.2.0"
+    "@parcel/css-linux-arm64-gnu" "1.2.0"
+    "@parcel/css-linux-arm64-musl" "1.2.0"
+    "@parcel/css-linux-x64-gnu" "1.2.0"
+    "@parcel/css-linux-x64-musl" "1.2.0"
+    "@parcel/css-win32-x64-msvc" "1.2.0"
+
 "@parcel/diagnostic@^2.2.1":
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/@parcel/diagnostic/-/diagnostic-2.2.1.tgz#9f75d6c6d9b9705ffbdb5c3f29ed421200e14bb1"


### PR DESCRIPTION
Towards #12 

```javascript
const lib = dlopen(
  "./testdata/node_modules/@parcel/css-darwin-arm64/parcel-css.darwin-arm64.node",
);

// Test case from @parcel/css
// https://github.com/parcel-bundler/parcel-css/blob/1e89b39cd922d2e577c8e39611f484a525fd8937/test.js
const result = lib.transform({
  filename: "test.css",
  minify: false,
  targets: {
    safari: 4 << 16,
    firefox: 3 << 16 | 5 << 8,
    opera: 10 << 16 | 5 << 8,
  },
  code: Deno.core.encode(`
  @import "foo.css";
  @import "bar.css" print;
  @import "baz.css" supports(display: grid);
  .foo {
      composes: bar;
      composes: baz from "baz.css";
      color: pink;
  }
  .bar {
      color: red;
      background: url(test.jpg);
  }
  `),
  drafts: {
    nesting: true,
  },
  cssModules: true,
  analyzeDependencies: true,
});

print(Deno.core.decode(result.code));
print(JSON.stringify(result.exports));
print(JSON.stringify(result.dependencies));
```